### PR TITLE
Add functional tests and schema validation for the /game endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,30 @@
             <artifactId>json-path</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/test/java/fun/GameTests.java
+++ b/src/test/java/fun/GameTests.java
@@ -1,6 +1,82 @@
 package fun;
 
-public class GameTests {
+import io.restassured.module.jsv.JsonSchemaValidator;
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import pojo.GamePojo;
+import utilities.TestBase;
+
+import java.io.File;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
+class GameTests extends TestBase {
+
+    GamePojo gamePojo;
+    JsonPath jsonPath;
+    String expectedText = "Playing Sudoku is fun!";
+    int[] fibonacci = new int[3];
+    String [] games = {"Chess", "Checkers", "Backgammon"};
+
+
+    @DisplayName("GET /game")
+    @Test
+    public void test01() {
+        int i = 0;
+        while (i < 3) {
+            jsonPath = given().contentType("application/json")
+                    .accept("application/json")
+                    .when().get("/game").prettyPeek()
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath();
+            gamePojo = jsonPath.getObject("$", GamePojo.class);
+            assertEquals(expectedText, gamePojo.getText());
+            fibonacci[i] = gamePojo.getId();
+            i++;
+        }
+        assertTrue(fibonacci[2] - fibonacci[1] == fibonacci[0]);
+    }
+
+
+    @DisplayName("GET /game/?name=gameName")
+    @Test
+    public void test02() {
+        int i = 0;
+        while (i < 3) {
+            String expectedText = "Playing " + games[i] + " is fun!";
+            JsonPath jsonPath = given()
+                    .contentType("application/json")
+                    .accept("application/json")
+                    .queryParams("name", games[i])
+                    .when().get("/game").prettyPeek()
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath();
+            gamePojo = jsonPath.getObject("$", GamePojo.class);
+            assertEquals(expectedText, gamePojo.getText());
+            fibonacci[i] = gamePojo.getId();
+            i++;
+        }
+        assertTrue(fibonacci[2] - fibonacci[1] == fibonacci[0]);
+    }
+
+
+    @DisplayName("GET /game/name= JsonSchemaValidator")
+    @Test
+    public void test03() {
+
+        given().contentType("application/json")
+                .accept("application/json")
+                .queryParam("name")
+                .when().get("/game").prettyPeek()
+                .then()
+                .statusCode(200)
+                .body(JsonSchemaValidator.matchesJsonSchema
+                        (new File("src/test/resources/jsonSchema.json")));
+    }
 }

--- a/src/test/java/pojo/GamePojo.java
+++ b/src/test/java/pojo/GamePojo.java
@@ -1,0 +1,13 @@
+package pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+
+    public class GamePojo {
+
+        private int id = 0;
+        private String text;
+}

--- a/src/test/java/utilities/TestBase.java
+++ b/src/test/java/utilities/TestBase.java
@@ -1,0 +1,16 @@
+package utilities;
+
+
+import org.junit.jupiter.api.BeforeAll;
+
+import static io.restassured.RestAssured.baseURI;
+import static io.restassured.RestAssured.port;
+
+public class TestBase {
+
+    @BeforeAll
+    public static void connectionSetUp() throws Exception {
+        baseURI = "http://localhost";
+        port = 8080;
+    }
+}

--- a/src/test/resources/jsonSchema.json
+++ b/src/test/resources/jsonSchema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "default": {},
+  "title": "Root Schema",
+  "required": [
+    "id",
+    "text"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "default": 0,
+      "title": "The id Schema",
+      "examples": [
+        3524578
+      ]
+    },
+    "text": {
+      "type": "string",
+      "default": "",
+      "title": "The text Schema",
+      "examples": [
+        "Playing Sudoku is fun!"
+      ]
+    }
+  },
+  "examples": [{
+    "id": 3524578,
+    "text": "Playing Sudoku is fun!"
+  }]
+}


### PR DESCRIPTION
This pull request adds functional tests for the /game endpoint using JUnit5 and Java. The tests use a GamePojo class to store and parse the JSON response from the service. In addition, the pull request includes a JSON schema validation test for the response of http://localhost:8080/game?name=, using the JsonSchemaValidator from RestAssured.

Changes:

Added GameTests class to test the /game endpoint.
Added functional tests for GET /game and GET /game/?name=gameName.
Added schema validation test for GET /game/name= using the jsonSchema.json file.
Created a GamePojo class to store and parse the JSON response.
Refactored TestBase class for better readability and organization.
Testing:

Ran GameTests class locally to ensure all tests passed.
Verified that schema validation test passes with the valid response and fails with an invalid response.
Please review and let me know if there are any changes or improvements that I can make to this pull request. 

Thanks!
Viacheslav Vedeshenkov
Test Automation Engineer

